### PR TITLE
use upstart provider on ubuntu trusty

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -66,6 +66,13 @@ service 'keystone' do
   service_name platform_options['keystone_service']
   supports status: true, restart: true
 
+  case node["platform"]
+  when "ubuntu"
+    if node["platform_version"].to_f >= 14.04
+      provider Chef::Provider::Service::Upstart
+    end
+  end
+
   action [:enable]
 
   notifies :run, 'execute[Keystone: sleep]', :immediately


### PR DESCRIPTION
keystone package on trusty does not come with init script thus "enable" action fails when provider is not set to upstart
